### PR TITLE
fix: support non root user and install specified aqua version

### DIFF
--- a/src/aqua-installer/devcontainer-feature.json
+++ b/src/aqua-installer/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "aqua-installer",
     "id": "aqua-installer",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Install aqua",
     "options": {
         "aqua_version": {

--- a/src/aqua-installer/install.sh
+++ b/src/aqua-installer/install.sh
@@ -38,9 +38,6 @@ if ! has_command curl && ! has_command wget; then
 	fi
 fi
 
-pwd
-ls
-
 url=https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.0/aqua-installer
 
 if [ "$_REMOTE_USER" = root ]; then

--- a/src/aqua-installer/install.sh
+++ b/src/aqua-installer/install.sh
@@ -30,7 +30,7 @@ if ! has_command curl && ! has_command wget; then
 	if has_command apt-get; then
 		apt-get update -y
 		apt-get install -y curl
-	elif has_command apk > /dev/null 2>&1; then
+	elif has_command apk; then
 		apk add curl
 	else
 		log_error "Neither curl nor wget is found. Please install either curl or wget to download aqua"

--- a/src/aqua-installer/install.sh
+++ b/src/aqua-installer/install.sh
@@ -57,7 +57,7 @@ echo "8299de6c19a8ff6b2cc6ac69669cf9e12a96cece385658310aea4f4646a5496d  aqua-ins
 
 chmod a+x aqua-installer
 if [ "$_REMOTE_USER" = root ]; then
-	./aqua-installer "$AQUA_VERSION"
+	./aqua-installer -v "$AQUA_VERSION"
 else
 	if ! has_command sudo; then
 		if has_command apt-get; then
@@ -70,7 +70,7 @@ else
 			exit 1
 		fi
 	fi
-	sudo -u "$_REMOTE_USER" ./aqua-installer "$AQUA_VERSION"
+	sudo -u "$_REMOTE_USER" ./aqua-installer -v "$AQUA_VERSION"
 fi
 
 rm -R "$tempdir"

--- a/src/aqua-installer/install.sh
+++ b/src/aqua-installer/install.sh
@@ -57,7 +57,7 @@ echo "8299de6c19a8ff6b2cc6ac69669cf9e12a96cece385658310aea4f4646a5496d  aqua-ins
 
 chmod a+x aqua-installer
 if [ "$_REMOTE_USER" = root ]; then
-	./aqua-installer
+	./aqua-installer "$AQUA_VERSION"
 else
 	if ! has_command sudo; then
 		if has_command apt-get; then
@@ -70,7 +70,7 @@ else
 			exit 1
 		fi
 	fi
-	sudo -u "$_REMOTE_USER" ./aqua-installer
+	sudo -u "$_REMOTE_USER" ./aqua-installer "$AQUA_VERSION"
 fi
 
 rm -R "$tempdir"

--- a/test/aqua-installer/alpine-nonroot.sh
+++ b/test/aqua-installer/alpine-nonroot.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+aqua -v

--- a/test/aqua-installer/alpine-nonroot/Dockerfile
+++ b/test/aqua-installer/alpine-nonroot/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.19.1
+RUN apk add sudo && \
+    sed -i "s|# %wheel ALL=(ALL:ALL) NOPASSWD: ALL|%wheel ALL=(ALL:ALL) NOPASSWD: ALL|" /etc/sudoers && \
+    adduser -u 1000 -G wheel -D vscode && \
+    rm -rf /var/cache/apk/*
+USER vscode

--- a/test/aqua-installer/scenarios.json
+++ b/test/aqua-installer/scenarios.json
@@ -20,5 +20,18 @@
                 "aqua_version": "v2.27.0"
             }
         }
+    },
+    "alpine-nonroot": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "remoteEnv": {
+            "PATH": "/home/vscode/.local/share/aquaproj-aqua/bin:${containerEnv:PATH}"
+        },
+        "features": {
+            "aqua-installer": {
+                "aqua_version": "v2.27.0"
+            }
+        }
     }
 }


### PR DESCRIPTION
Close #14

- Install aqua for not root user but `$_REMOTE_USER`
- refactor
  - remove debug codes
  - remove an unnecessary redirect
- Fix a bug that the latest version is always installed regardless of `AQUA_VERSION`